### PR TITLE
Fix for issue #1

### DIFF
--- a/tap/Manage.cs
+++ b/tap/Manage.cs
@@ -403,12 +403,8 @@ namespace tap
             string[] files = Directory.GetFiles(targetDir, patchFile, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
             if(files.Length == 0)
             {
-                MessageBox.Show(string.Format("Cannot find existing file {0}, please select target folder", patchFile), "File doesn't yet exist", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(string.Format("Cannot find existing file {0}. Please confirm target folder that the new file should be added to", patchFile), "File doesn't yet exist", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 target = SelectTargetDirectory();
-                if (target != null)
-                {
-                    target = FindPatchFileInDir(patchFile, target, true);
-                }
             }
             else if (files.Length > 1)
             {


### PR DESCRIPTION
Warning now provided when files in patch maybe out-of-date.

Also includes a small fix to the logic that tries to find the target file in the target directory. It was possible to return just the name of the directory and not the file within it, so the logic is now recursive until we have a single file or the user cancels.